### PR TITLE
Msi affinity

### DIFF
--- a/scripts/optional_helpers/interrupt_affinity_auto.ps1
+++ b/scripts/optional_helpers/interrupt_affinity_auto.ps1
@@ -240,7 +240,7 @@ foreach ($item in $relevantData) {
 	}
 	if ($item.ClassType -eq 'Mouse') {
 	 	Set-ItemProperty -Path $parentAffinityPath -Name "DevicePriority" -Value 3 -Force -Type Dword -ErrorAction Ignore
-		Set-ItemProperty -Path $parentMsiPath -Name "MSISupported" -Value 0 -Force -Type Dword -ErrorAction Ignore
+		Set-ItemProperty -Path $parentMsiPath -Name "MSISupported" -Value 1 -Force -Type Dword -ErrorAction Ignore
 		Set-ItemProperty -Path $parentMsiPath -Name "MessageNumberLimit" -Value 2048 -Force -Type Dword -ErrorAction Ignore
 	}
 	if ($item.ClassType -eq 'Display') {

--- a/scripts/optional_helpers/interrupt_affinity_auto.ps1
+++ b/scripts/optional_helpers/interrupt_affinity_auto.ps1
@@ -240,7 +240,6 @@ foreach ($item in $relevantData) {
 	}
 	if ($item.ClassType -eq 'Mouse') {
 	 	Set-ItemProperty -Path $parentAffinityPath -Name "DevicePriority" -Value 3 -Force -Type Dword -ErrorAction Ignore
-		Set-ItemProperty -Path $parentMsiPath -Name "MSISupported" -Value 1 -Force -Type Dword -ErrorAction Ignore
 		Set-ItemProperty -Path $parentMsiPath -Name "MessageNumberLimit" -Value 2048 -Force -Type Dword -ErrorAction Ignore
 	}
 	if ($item.ClassType -eq 'Display') {


### PR DESCRIPTION
Since this is now set to 2048, MSI support needs to be one since the goal is to enable MSI-X. Since everything is set to Msi supported = 1 at the start this work the same as the network is set up.